### PR TITLE
Create fix

### DIFF
--- a/fix
+++ b/fix
@@ -1,0 +1,20 @@
+ C:\Users\admin\Craft-World-Auto-Bot\index.js
+    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
+    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
+    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
+    at Function._load (node:internal/modules/cjs/loader:1211:37)
+    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
+    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
+    at Module.require (node:internal/modules/cjs/loader:1487:12)
+    at require (node:internal/modules/helpers:135:16)
+    at Object.<anonymous> (C:\Users\admin\Craft-World-Auto-Bot\auth.js:1:20)
+    at Module._compile (node:internal/modules/cjs/loader:1730:14) {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [
+    'C:\\Users\\admin\\Craft-World-Auto-Bot\\auth.js',
+    'C:\\Users\\admin\\Craft-World-Auto-Bot\\index.js'
+  ]
+}
+
+Node.js v22.16.0
+help


### PR DESCRIPTION
 C:\Users\admin\Craft-World-Auto-Bot\index.js
    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
    at Function._load (node:internal/modules/cjs/loader:1211:37)
    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
    at Module.require (node:internal/modules/cjs/loader:1487:12)
    at require (node:internal/modules/helpers:135:16)
    at Object.<anonymous> (C:\Users\admin\Craft-World-Auto-Bot\auth.js:1:20)
    at Module._compile (node:internal/modules/cjs/loader:1730:14) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    'C:\\Users\\admin\\Craft-World-Auto-Bot\\auth.js',
    'C:\\Users\\admin\\Craft-World-Auto-Bot\\index.js'
  ]
}

Node.js v22.16.0